### PR TITLE
add proxy admin+control ports to the ignored ports list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Specifically ignore the control and admin ports when intialising the proxies ([#48](https://github.com/giantswarm/linkerd2-app/pull/48))
+
 ## [0.6.0] - 2021-08-03
 
 ### Changed

--- a/helm/linkerd2-app/values.yaml
+++ b/helm/linkerd2-app/values.yaml
@@ -117,7 +117,7 @@ proxy:
 # proxy-init configuration
 proxyInit:
   # -- Default set of inbound ports to skip via itpables
-  ignoreInboundPorts: ""
+  ignoreInboundPorts: "4190,4191"
   # -- Default set of outbound ports to skip via itpables
   ignoreOutboundPorts: ""
   image:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/18653

this pr:

- adds the proxy admin & control ports to the ignored ports list.

background:

this is a bit of a weird one which I ran into yesterday - the tap and top sections of the dashboard didn't work - after troubleshooting with a Linkerd maintainer we discovered that the proxies were also intercepting traffic destined for the tap server port on the proxy as if it were traffic they were supposed to route (see [this issue](https://github.com/linkerd/linkerd2/issues/6224)).

adding these ports to the ignored inbound ports means that the proxies will never try and forward this traffic on. this is an issue with the Helm chart and should be fixed in the next release.

- [x] changelog updated
