### PR TITLE
Avoids proxy-injector to try to inject linkerd's proxy on giantswarm chart-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Bump version 2.12.1.
+- Avoids the proxy-injector to inspect giantswarm namespace and try to inject linkerd proxy on the chart-operator
 
 ## [0.7.5] - 2022-10-13
 

--- a/helm/linkerd2-app/values.yaml
+++ b/helm/linkerd2-app/values.yaml
@@ -349,6 +349,7 @@ proxyInjector:
       values:
       - kube-system
       - cert-manager
+      - giantswarm
 
   # -- Object selector used by admission webhook.
   objectSelector:


### PR DESCRIPTION
Fixes #129 

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR modifies the namespaceSelector of the proxy-injector to avoid that a failing proxy-injector will make the mutationwebhook to fail and impact critical workloads like the chart-operator on giantswarm namespace.

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] I am confident my changes don't break existing installations (for chart changes)
- [x] Changelog entry has been added
