### PR TITLE
Enable podMonitor with custom relabelings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add custom relabling rules to PodMonitor and enable PodMonitor ([#188](https://github.com/giantswarm/linkerd-control-plane-app/pull/188)).
+
 ## [1.3.1] - 2023-12-14
 
 ### Changed

--- a/helm/linkerd-control-plane/templates/podmonitor.yaml
+++ b/helm/linkerd-control-plane/templates/podmonitor.yaml
@@ -30,6 +30,9 @@ spec:
             - __meta_kubernetes_pod_container_name
           action: replace
           targetLabel: component
+        {{- with $podMonitor.relabelings }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 {{- if and $podMonitor.enabled $podMonitor.serviceMirror.enabled }}
 ---
@@ -64,6 +67,9 @@ spec:
             - __meta_kubernetes_pod_container_name
           action: replace
           targetLabel: component
+        {{- with $podMonitor.relabelings }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 {{- if and $podMonitor.enabled $podMonitor.proxy.enabled }}
 ---

--- a/helm/linkerd-control-plane/values.yaml
+++ b/helm/linkerd-control-plane/values.yaml
@@ -554,7 +554,7 @@ spValidatorResources: *controller_resources
 # Prometheus Operator PodMonitor configuration
 podMonitor:
   # -- Enables the creation of Prometheus Operator [PodMonitor](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor)
-  enabled: false
+  enabled: true
   # -- Interval at which metrics should be scraped
   scrapeInterval: 10s
   # -- Iimeout after which the scrape is ended
@@ -570,7 +570,17 @@ podMonitor:
         - linkerd-jaeger
   serviceMirror:
     # -- Enables the creation of PodMonitor for the Service Mirror component
-    enabled: true
+    enabled: false
   proxy:
     # -- Enables the creation of PodMonitor for the data-plane
     enabled: true
+  # -- Add custom relabeling rules to PodMonitor
+  relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app
+      targetLabel: app
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR enables PodMonitor and adds the option to add custom relabeling rules to it.

Towards https://github.com/giantswarm/giantswarm/issues/28518

## Checklist

- [ ] Automated test are working (for chart changes)
- [x] I am confident my changes don't break existing installations (for chart changes)
- [x] Changelog entry has been added
